### PR TITLE
Specify 'host_ip' for Vagrant forwarded ports

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant.configure(2) do |config|
 
   config.vm.synced_folder ".", "/srv/calthorpe/urbanfootprint", owner: CALTHORPE_UID, group: CALTHORPE_GID
 
-  config.vm.network "forwarded_port", guest: 80, host: 3333
-  config.vm.network "forwarded_port", guest: 5432, host: 5555
+  config.vm.network "forwarded_port", guest: 80, host: 3333, host_ip: "localhost"
+  config.vm.network "forwarded_port", guest: 5432, host: 5555, host_ip: "localhost"
 
   if VAGRANT_COMMAND == "ssh"
     config.ssh.username = "calthorpe"

--- a/Vagrantfile-prebuilt
+++ b/Vagrantfile-prebuilt
@@ -20,8 +20,8 @@ Vagrant.configure(2) do |config|
   config.vm.box     = VM_BOX_NAME
   config.vm.box_url = "https://s3-us-west-2.amazonaws.com/uf-provisioning/urbanfootprint-2016-09-04.box"
 
-  config.vm.network "forwarded_port", guest: 80, host: 3333
-  config.vm.network "forwarded_port", guest: 5432, host: 5555
+  config.vm.network "forwarded_port", guest: 80, host: 3333, host_ip: "localhost"
+  config.vm.network "forwarded_port", guest: 5432, host: 5555, host_ip: "localhost"
 
   if VAGRANT_COMMAND == "ssh"
     config.ssh.username = "calthorpe"


### PR DESCRIPTION
This is a workaround for Windows because of Vagrant issue #8395. This has been reported by Windows UrbanFootprint users via #3.

Vagrant repo issue and fix:
https://github.com/mitchellh/vagrant/issues/8395
https://github.com/mitchellh/vagrant/pull/8399