### PR TITLE
Use Hashicorp Atlas service for Vagrant box file hosting

### DIFF
--- a/Vagrantfile-prebuilt
+++ b/Vagrantfile-prebuilt
@@ -11,14 +11,11 @@ VM_MEMORY = ENV['UF_VM_MEMORY']  || 4096
 VM_CPUS   = ENV['UF_VM_CPUS']    || 2
 VM_PROXY  = ENV['VAGRANT_PROXY'] || false
 
-VM_BOX_NAME = "urbanfootprint-prebuilt-2016-09-04"
-
 Vagrant.configure(2) do |config|
   ############################################################################
   # GLOBAL SETTINGS
   ############################################################################
-  config.vm.box     = VM_BOX_NAME
-  config.vm.box_url = "https://s3-us-west-2.amazonaws.com/uf-provisioning/urbanfootprint-2016-09-04.box"
+  config.vm.box     = "urbanfootprint/urbanfootprint"
 
   config.vm.network "forwarded_port", guest: 80, host: 3333, host_ip: "localhost"
   config.vm.network "forwarded_port", guest: 5432, host: 5555, host_ip: "localhost"
@@ -38,7 +35,7 @@ Vagrant.configure(2) do |config|
   ############################################################################
   # VIRTUALBOX
   ############################################################################
-  config.vm.define VM_BOX_NAME do |subvm|
+  config.vm.define "urbanfootprint" do |subvm|
     subvm.vm.hostname = "urbanfootprint"
 
     # Copy the vagrant user's list of authorized_keys to the calthorpe


### PR DESCRIPTION
* Moves hosting of the prebuilt/quickstart Vagrant box to the Hashicorp Atlas hosted service: https://atlas.hashicorp.com/urbanfootprint/boxes/urbanfootprint
* Updates Vagrant box with current code from repo (important following PR #2)
