### PR TITLE
Modify ghg per mile assumption in chart

### DIFF
--- a/footprint/client/configuration/sacog/presentation/sacog_result.py
+++ b/footprint/client/configuration/sacog/presentation/sacog_result.py
@@ -571,7 +571,7 @@ class SacogResultConfigurationFixtures(ResultConfigurationFixture):
                     labels=['Emissions'],
                     stackable=False,
                     is_stacked=False,
-                    create_query=lambda result_config: 'SELECT SUM(vmt_annual_w_trucks) as vehicle_emissions__sum from %({0})s'.format(DbEntityKey.VMT),
+                    create_query=lambda result_config: 'SELECT SUM(vmt_annual_w_trucks) *  0.9061 as vehicle_emissions__sum from %({0})s'.format(DbEntityKey.VMT),
                     sort_priority=ResultSort.BASE
                 ),
                 ResultConfiguration(


### PR DESCRIPTION
Previously, the system assumed that our ghg per VMT rate was 1.0 (did this by leaving out the multiplication factor). This edits that assumption to be the US average according to the epa: https://www.epa.gov/greenvehicles/greenhouse-gas-emissions-typical-passenger-vehicle-0